### PR TITLE
[Feat] #12 add user signup API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
   ],
   "plugins": ["prettier", "@typescript-eslint"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "import/no-anonymous-default-export": [2, { "allowArrowFunction": true }]
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,10 +8,9 @@ generator client {
 }
 
 model user_tb {
-  u_userid        String      @id
-  u_loginid       String      @unique
-  u_passwd        String
-  u_email         String      @unique
-  u_name          String
-  u_date          DateTime
+  user_id    String   @id @default(uuid()) @db.VarChar(36)
+  passwd     String
+  email      String   @unique
+  name       String
+  created_at DateTime @default(now())
 }

--- a/src/backend/models/User.ts
+++ b/src/backend/models/User.ts
@@ -1,0 +1,7 @@
+export interface User {
+  user_id: string;
+  passwd: string;
+  email: string;
+  name: string;
+  created_at: Date;
+}

--- a/src/backend/repositories/PrismaUserRepository.ts
+++ b/src/backend/repositories/PrismaUserRepository.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client';
+import { User } from 'models/User';
+import { UserRepository } from 'repositories/UserRepository';
+
+export class PrismaUserRepository implements UserRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async getUserByEmail(email: string): Promise<User | null> {
+    const user = await this.prisma.user_tb.findUnique({
+      where: { email: email }
+    });
+    return user;
+  }
+
+  async createUser(user: Omit<User, 'user_id' | 'created_at'>): Promise<User> {
+    const createdUser = await this.prisma.user_tb.create({ data: user });
+    return createdUser;
+  }
+}

--- a/src/backend/repositories/UserRepository.ts
+++ b/src/backend/repositories/UserRepository.ts
@@ -1,0 +1,6 @@
+import { User } from 'models/User';
+
+export interface UserRepository {
+  getUserByEmail(email: string): Promise<User | null>;
+  createUser(user: Omit<User, 'user_id' | 'created_at'>): Promise<User>;
+}

--- a/src/backend/services/UserService.ts
+++ b/src/backend/services/UserService.ts
@@ -1,0 +1,16 @@
+import { User } from '../models/User';
+import { UserRepository } from '../repositories/UserRepository';
+
+export class SignupUseCase {
+  constructor(private userRepository: UserRepository) {}
+
+  async execute(user: Omit<User, 'user_id' | 'created_at'>): Promise<User> {
+    const existingUser = await this.userRepository.getUserByEmail(user.email);
+    if (existingUser) {
+      throw new Error('User with this email already exists');
+    }
+
+    const createdUser = await this.userRepository.createUser(user);
+    return createdUser;
+  }
+}

--- a/src/pages/api/user/signup.ts
+++ b/src/pages/api/user/signup.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+import { SignupUseCase } from 'services/UserService';
+import { PrismaUserRepository } from 'repositories/PrismaUserRepository';
+
+const prisma = new PrismaClient();
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'POST') {
+    const { email, name, passwd } = req.body;
+
+    const userRepository = new PrismaUserRepository(prisma);
+    const signupUseCase = new SignupUseCase(userRepository);
+    try {
+      const newUser = await signupUseCase.execute({ passwd, email, name });
+      res.status(201).json({ user: newUser });
+    } catch (error) {
+      if (error instanceof Error) {
+        res.status(500).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: 'An unknown error occurred' });
+      }
+    }
+  } else {
+    res.status(405).json({ error: 'Method not allowed' });
+  }
+};


### PR DESCRIPTION
## 🍀 개요

- 유저 회원가입에 필요한 API 및 백엔드 로직을 추가했습니다.

## ✏️ 작업 내용

- [x] 유저 테이블 칼럼 명 변경.(u_ prefix 삭제, date 이름 변경) - 864b41c315520a1a0061af227a18b01fe2f3d36c
- [x] eslint rule 추가 - 2475f89a1aae1e618e20b629a67c209fb707eeaf
- [x] 유저 회원가입에 필요한 API, 백엔드 로직 추가 -  c308c94620a257b862e1e06a60d94550c9617f4d
<img width="1019" alt="스크린샷 2023-04-28 오후 3 28 57" src="https://user-images.githubusercontent.com/65802921/235071364-04bdbce0-0d88-4b5f-859f-43bd2141ffe4.png">


## 🔎 추가 정보

정상 response 오는것 postman으로 확인 완료했습니다.
추가로 userid, created_at 칼럼 백엔드가 아닌 DB에서 필드 채우도록 변경했습니다. 이유는 uuid 패키지 따로 설치안해도 랜덤 id값 DB에서 부여 가능한것으로 확인했기 때문입니다.
@kobums 회원가입에 필요한 다른 API가 있으면 말해주세요
- close #12 
