### PR TITLE
[Feat] #21 add email check api

### DIFF
--- a/src/backend/repositories/PrismaUserRepository.ts
+++ b/src/backend/repositories/PrismaUserRepository.ts
@@ -7,7 +7,7 @@ export class PrismaUserRepository implements UserRepository {
 
   async getUserByEmail(email: string): Promise<User | null> {
     const user = await this.prisma.user_tb.findUnique({
-      where: { email: email }
+      where: { email }
     });
     return user;
   }

--- a/src/backend/services/UserService.ts
+++ b/src/backend/services/UserService.ts
@@ -1,10 +1,10 @@
 import { User } from '../models/User';
 import { UserRepository } from '../repositories/UserRepository';
 
-export class SignupUseCase {
+export class UserUseCase {
   constructor(private userRepository: UserRepository) {}
 
-  async execute(user: Omit<User, 'user_id' | 'created_at'>): Promise<User> {
+  async signup(user: Omit<User, 'user_id' | 'created_at'>): Promise<User> {
     const existingUser = await this.userRepository.getUserByEmail(user.email);
     if (existingUser) {
       throw new Error('User with this email already exists');
@@ -12,5 +12,10 @@ export class SignupUseCase {
 
     const createdUser = await this.userRepository.createUser(user);
     return createdUser;
+  }
+
+  async checkEmail(email: string): Promise<boolean> {
+    const user = await this.userRepository.getUserByEmail(email);
+    return user ? true : false;
   }
 }

--- a/src/backend/services/UserService.ts
+++ b/src/backend/services/UserService.ts
@@ -1,5 +1,5 @@
-import { User } from '../models/User';
-import { UserRepository } from '../repositories/UserRepository';
+import { User } from 'models/User';
+import { UserRepository } from 'repositories/UserRepository';
 
 export class UserUseCase {
   constructor(private userRepository: UserRepository) {}

--- a/src/pages/api/user/check-email.ts
+++ b/src/pages/api/user/check-email.ts
@@ -6,14 +6,18 @@ import { PrismaUserRepository } from 'repositories/PrismaUserRepository';
 const prisma = new PrismaClient();
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.method === 'POST') {
-    const { email, name, passwd } = req.body;
+  if (req.method === 'GET') {
+    const { email } = req.query;
 
     const userRepository = new PrismaUserRepository(prisma);
     const userService = new UserUseCase(userRepository);
     try {
-      const newUser = await userService.signup({ passwd, email, name });
-      res.status(201).json({ user: newUser });
+      if (email && typeof email === 'string') {
+        const isAvailable = await userService.checkEmail(email);
+        res.status(200).json({ isAvailable });
+      } else {
+        res.status(400).json({ error: 'Email is required' });
+      }
     } catch (error) {
       if (error instanceof Error) {
         res.status(500).json({ error: error.message });

--- a/src/pages/api/user/signup.ts
+++ b/src/pages/api/user/signup.ts
@@ -12,8 +12,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     const userRepository = new PrismaUserRepository(prisma);
     const userService = new UserUseCase(userRepository);
     try {
-      const newUser = await userService.signup({ passwd, email, name });
-      res.status(201).json({ user: newUser });
+      const isAvailableEmail = await !userService.checkEmail(email);
+      if (isAvailableEmail) {
+        const newUser = await userService.signup({ passwd, email, name });
+        res.status(201).json({ user: newUser });
+      } else {
+        res.status(409).json({ error: 'User with this email already exists' });
+      }
     } catch (error) {
       if (error instanceof Error) {
         res.status(500).json({ error: error.message });


### PR DESCRIPTION
## 🍀 개요

- 회원가입에 사용되는 이메일 중복확인 api 추가

## ✏️ 작업 내용

- [x] 이메일 중복 확인 api 추가 - a35f0a3f731cced8033de9f2882ec8a941db1872
- [x] 객체 단축 리팩터링 - 5d350d529ce30f181204b8c4ff408d45fcda1107
- [x] 회원가입 시 email check 하는 부분 에러코드 추가 (409 error) 45456553ba1ddbd58c71244317fd281ae2bb3e18
<img width="1010" alt="스크린샷 2023-05-07 오후 12 26 04" src="https://user-images.githubusercontent.com/65802921/236656032-05b1d8e9-371b-4b06-be18-f34f45e8f80e.png">

## 🔎 추가 정보
정상 response 오는것 postman으로 확인 완료.
get으로 요청해야합니다. 자세한것은 노션 API 문서 확인하시기 바랍니다.
- close #21 