### PR TITLE
[Feat] #38 add routines get api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@types/react-dom": "18.0.11",
         "axios": "^1.4.0",
         "bcrypt": "^5.1.0",
+        "date-fns": "^2.30.0",
+        "date-fns-tz": "^2.0.0",
         "eslint": "8.38.0",
         "eslint-config-next": "13.3.0",
         "jsonwebtoken": "^9.0.0",
@@ -1979,6 +1981,29 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6691,6 +6716,20 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
+    },
+    "date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "requires": {}
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@types/react-dom": "18.0.11",
     "axios": "^1.4.0",
     "bcrypt": "^5.1.0",
+    "date-fns": "^2.30.0",
+    "date-fns-tz": "^2.0.0",
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
     "jsonwebtoken": "^9.0.0",

--- a/prisma/migrations/20230523105403_chane_days_of_week_binary_col_type_in_routine_table/migration.sql
+++ b/prisma/migrations/20230523105403_chane_days_of_week_binary_col_type_in_routine_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `routine` MODIFY `days_of_week_binary` VARCHAR(191) NOT NULL;

--- a/prisma/migrations/20230523111946_add_created_at_col_in_routine_instance/migration.sql
+++ b/prisma/migrations/20230523111946_add_created_at_col_in_routine_instance/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `routine_instance` ADD COLUMN `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model routine {
 model routine_instance {
   routine_instance_id    String                   @id @default(uuid())
   routine_id             String
+  created_at             DateTime                 @default(now())
   routine                routine                  @relation(fields: [routine_id], references: [routine_id])
   count_routine_instance count_routine_instance[]
   time_routine_instance  time_routine_instance[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,7 +29,7 @@ model routine {
   title               String
   type                RoutineType
   is_repeat           Boolean
-  days_of_week_binary Int
+  days_of_week_binary String
   created_at          DateTime           @default(now())
   deleted_at          DateTime?
   routine_instance    routine_instance[]

--- a/src/backend/models/Routine.ts
+++ b/src/backend/models/Routine.ts
@@ -1,0 +1,25 @@
+import { RoutineType as PrismaRoutineType } from '@prisma/client';
+
+export interface Routine {
+  routine_id: string;
+  user_id: string;
+  title: string;
+  type: PrismaRoutineType;
+  is_repeat: boolean;
+  days_of_week_binary: string;
+  created_at: Date;
+  deleted_at: Date | null;
+}
+
+export interface RoutineInstance {
+  routine_instance_id: string;
+  routine_id: string;
+  created_at: Date;
+}
+
+export interface RoutineInstanceWithGoal {
+  routine_instance_id: string;
+  created_at: Date;
+  goal: boolean | number;
+  progress: boolean | number;
+}

--- a/src/backend/repositories/PrismaRoutineInstanceRepository.ts
+++ b/src/backend/repositories/PrismaRoutineInstanceRepository.ts
@@ -1,0 +1,58 @@
+import {
+  PrismaClient,
+  bool_routine_instance,
+  count_routine_instance,
+  time_routine_instance
+} from '@prisma/client';
+import { Routine } from 'models/Routine';
+import { RoutineInstanceWithGoal } from 'models/Routine';
+import { RoutineInstanceRepository } from 'repositories/RoutineInstanceRepository';
+
+export class PrismaRoutineInstanceRepository
+  implements RoutineInstanceRepository
+{
+  constructor(private prisma: PrismaClient) {}
+
+  async getRoutineInstance(
+    routine: Routine
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const routineInstance = await this.prisma.routine_instance.findFirst({
+      where: { routine_id: routine.routine_id }
+    });
+
+    if (!routineInstance) {
+      return null;
+    }
+
+    let routineInstanceGoal:
+      | bool_routine_instance
+      | count_routine_instance
+      | time_routine_instance
+      | null = null;
+
+    if (routine.type === 'bool') {
+      routineInstanceGoal = await this.prisma.bool_routine_instance.findFirst({
+        where: { routine_instance_id: routineInstance.routine_instance_id }
+      });
+    } else if (routine.type === 'count') {
+      routineInstanceGoal = await this.prisma.count_routine_instance.findFirst({
+        where: { routine_instance_id: routineInstance.routine_instance_id }
+      });
+    } else if (routine.type === 'time') {
+      routineInstanceGoal = await this.prisma.time_routine_instance.findFirst({
+        where: { routine_instance_id: routineInstance.routine_instance_id }
+      });
+    }
+
+    if (routineInstanceGoal) {
+      return {
+        routine_instance_id: routineInstance.routine_instance_id,
+        created_at: routineInstance.created_at,
+        goal: routineInstanceGoal.goal,
+        progress: routineInstanceGoal.progress
+      };
+    } else {
+      throw Error('routine_instance is not created.');
+    }
+  }
+}

--- a/src/backend/repositories/PrismaRoutineRepository.ts
+++ b/src/backend/repositories/PrismaRoutineRepository.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client';
+import { Routine } from 'models/Routine';
+import { RoutineRepository } from 'repositories/RoutineRepository';
+
+export class PrismaRoutineRepository implements RoutineRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async getRoutinesByUserId(user_id: string): Promise<Routine[]> {
+    const routine = await this.prisma.routine.findMany({
+      where: { user_id: user_id }
+    });
+
+    return routine;
+  }
+}

--- a/src/backend/repositories/PrismaUserRepository.ts
+++ b/src/backend/repositories/PrismaUserRepository.ts
@@ -12,6 +12,13 @@ export class PrismaUserRepository implements UserRepository {
     return user;
   }
 
+  async getUserById(user_id: string): Promise<User | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { user_id }
+    });
+    return user;
+  }
+
   async createUser(user: SignUpRequest): Promise<User> {
     const createdUser = await this.prisma.user.create({ data: user });
     return createdUser;

--- a/src/backend/repositories/RoutineInstanceRepository.ts
+++ b/src/backend/repositories/RoutineInstanceRepository.ts
@@ -1,0 +1,5 @@
+import { Routine, RoutineInstanceWithGoal } from 'models/Routine';
+
+export interface RoutineInstanceRepository {
+  getRoutineInstance(routine: Routine): Promise<RoutineInstanceWithGoal | null>;
+}

--- a/src/backend/repositories/RoutineRepository.ts
+++ b/src/backend/repositories/RoutineRepository.ts
@@ -1,0 +1,5 @@
+import { Routine } from 'models/Routine';
+
+export interface RoutineRepository {
+  getRoutinesByUserId(user_id: string): Promise<Routine[]>;
+}

--- a/src/backend/repositories/UserRepository.ts
+++ b/src/backend/repositories/UserRepository.ts
@@ -2,5 +2,6 @@ import { User, SignUpRequest } from 'models/User';
 
 export interface UserRepository {
   getUserByEmail(email: string): Promise<User | null>;
+  getUserById(user_id: string): Promise<User | null>;
   createUser(user: SignUpRequest): Promise<User>;
 }

--- a/src/backend/services/RoutineService.ts
+++ b/src/backend/services/RoutineService.ts
@@ -1,0 +1,45 @@
+import { Routine } from 'models/Routine';
+import { RoutineRepository } from 'repositories/RoutineRepository';
+import { RoutineInstanceRepository } from 'repositories/RoutineInstanceRepository';
+import { utcToZonedTime } from 'date-fns-tz';
+import { getDay } from 'date-fns';
+
+export class RoutineUseCase {
+  constructor(
+    private routineRepository: RoutineRepository,
+    private routineInstanceRepository: RoutineInstanceRepository
+  ) {}
+
+  async getTodayRoutine(userId: string) {
+    const day = ['일', '월', '화', '수', '목', '금', '토'];
+    const routines = await this.routineRepository.getRoutinesByUserId(userId);
+    const filteredTodayRoutines = this.filterTodayRoutines(routines);
+    return filteredTodayRoutines.map(async (routine) => {
+      const daysOfWeek = routine.days_of_week_binary
+        .split('')
+        .map((binaryDay, idx) => {
+          if (binaryDay === '1') {
+            return day[idx];
+          }
+          return binaryDay;
+        })
+        .filter((d) => d !== '0');
+      const routineInstance =
+        await this.routineInstanceRepository.getRoutineInstance(routine);
+      return {
+        ...routineInstance,
+        title: routine.title,
+        type: routine.type,
+        days_of_week: daysOfWeek
+      };
+    });
+  }
+
+  filterTodayRoutines(routines: Routine[]) {
+    const koreaTime = utcToZonedTime(new Date(), 'Asia/Seoul');
+    const day = getDay(koreaTime);
+    return routines.filter(
+      (routine) => routine.days_of_week_binary.charAt(day) === '1'
+    );
+  }
+}

--- a/src/backend/services/UserService.ts
+++ b/src/backend/services/UserService.ts
@@ -33,6 +33,11 @@ export class UserUseCase {
     return searchUser;
   }
 
+  async getUserById(userId: string): Promise<User | null> {
+    const searchUser = await this.userRepository.getUserById(userId);
+    return searchUser;
+  }
+
   async encryptPassword(password: string): Promise<string> {
     const saltRounds = 10;
     const hashedPassword = await bycrypt.hash(password, saltRounds);

--- a/src/backend/utils/dateUtil.ts
+++ b/src/backend/utils/dateUtil.ts
@@ -1,0 +1,11 @@
+import { isValid, parseISO } from 'date-fns';
+
+function isValidDate(date: string): boolean {
+  const regEx = /^\d{4}-\d{2}-\d{2}$/;
+  if (!date.match(regEx)) return false; // Invalid format
+  const d = parseISO(date);
+  if (!isValid(d)) return false; // Invalid date
+  return true;
+}
+
+export { isValidDate };

--- a/src/pages/api/user/[userId]/routines.ts
+++ b/src/pages/api/user/[userId]/routines.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+import { UserUseCase } from 'services/UserService';
+import { RoutineUseCase } from 'services/RoutineService';
+import { PrismaUserRepository } from 'repositories/PrismaUserRepository';
+import { PrismaRoutineRepository } from 'repositories/PrismaRoutineRepository';
+import { PrismaRoutineInstanceRepository } from 'repositories/PrismaRoutineInstanceRepository';
+import { isValidDate } from '@/backend/utils/dateUtil';
+
+const prisma = new PrismaClient();
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'GET') {
+    const { userId, date } = req.query;
+
+    const userRepository = new PrismaUserRepository(prisma);
+    const userService = new UserUseCase(userRepository);
+
+    const routineRepository = new PrismaRoutineRepository(prisma);
+    const routineInstanceRepository = new PrismaRoutineInstanceRepository(
+      prisma
+    );
+    const routineService = new RoutineUseCase(
+      routineRepository,
+      routineInstanceRepository
+    );
+
+    if (!isValidDate(date as string)) {
+      return res.status(400).json({
+        error:
+          "Invalid request: 'date' query parameter must be in YYYY-MM-DD format."
+      });
+    }
+
+    try {
+      const user = await userService.getUserById(userId as string);
+      if (!user) {
+        return res
+          .status(404)
+          .json({ error: 'User with provided ID not found.' });
+      }
+
+      const routines = await routineService.getTodayRoutine(userId as string);
+      res.status(200).json(routines);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ error: 'Unexpected error occurred' });
+    }
+  } else {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+};


### PR DESCRIPTION
## 🍀 개요

GET /api/user/{userid}/routines api 추가 작업

## ✏️ 작업 내용

- [x] model 변경 - 785bd45c9b94ec0beb7013853d64c5a003438c3e, c951fdcd0d6eaad9d916bd20bb289ac82bcbcf5a
- [x] date 계산 라이브러리 추가 - ca788a0195e5bb967d78da46069a981072ffab27, 348bd9de54591c510bc74b90424fbac7c2c0a407
- [x] routine model 추가 - fd5a1d69af39b7f9b1a69bffa723e1492e8319fe
- [x] user에서 getUserById 함수 추가 - d548b370d8673aa75f0fa0a54e1d9924ef3a79a1
- [x] routine 관련 repositories 추가 - e5943a7cd5fecb4c033c61c3517d617d7315f729
- [x] routine 관련 service 추가 - 7ef07cb25beee36e929e50d9107d70228a29ff74
  1. userID 기반으로 routine찾기
  2. 찾은 routine 오늘 사용되는지 필터링
  3.  필터링한 routine 을 순회하면서 실제 routine_instance 찾아오기 (count_routine_instance, bool_routine_instance, time_routine_instance 의 정보도 합쳐서)
- [x] routine GET api 추가 - 100326185aebef3f205e233bbd05fb36294e22c9

## 🔎 추가 정보
- 전체적인 리팩토링은 아직 진행하지 않았습니다. (레이어 나누는 부분) 이 작업은 추후에 별도의 issue에서 작업할 예정입니다.
- close #38 