### PR TITLE
[Feat] #46 add routine post api

### DIFF
--- a/src/backend/models/Routine.ts
+++ b/src/backend/models/Routine.ts
@@ -19,7 +19,6 @@ export interface RoutineInstance {
 
 export interface RoutineInstanceWithGoal {
   routine_instance_id: string;
-  created_at: Date;
   goal: boolean | number;
   progress: boolean | number;
 }

--- a/src/backend/repositories/PrismaRoutineInstanceRepository.ts
+++ b/src/backend/repositories/PrismaRoutineInstanceRepository.ts
@@ -4,7 +4,7 @@ import {
   count_routine_instance,
   time_routine_instance
 } from '@prisma/client';
-import { Routine } from 'models/Routine';
+import { Routine, RoutineInstance } from 'models/Routine';
 import { RoutineInstanceWithGoal } from 'models/Routine';
 import { RoutineInstanceRepository } from 'repositories/RoutineInstanceRepository';
 
@@ -53,5 +53,44 @@ export class PrismaRoutineInstanceRepository
     } else {
       throw Error('routine_instance is not created.');
     }
+  }
+
+  async addRoutineInstance(routine_id: string): Promise<RoutineInstance> {
+    const routineInstance = await this.prisma.routine_instance.create({
+      data: {
+        routine_id
+      }
+    });
+    return routineInstance;
+  }
+
+  async addTimeRoutineInstance(
+    routine_instance_id: string,
+    goal: number
+  ): Promise<RoutineInstanceWithGoal> {
+    const addTimeRoutineInstance = this.prisma.time_routine_instance.create({
+      data: { routine_instance_id, goal, progress: 0 }
+    });
+    return addTimeRoutineInstance;
+  }
+
+  async addCountRoutineInstance(
+    routine_instance_id: string,
+    goal: number
+  ): Promise<RoutineInstanceWithGoal> {
+    const addCountRoutineInstance = this.prisma.count_routine_instance.create({
+      data: { routine_instance_id, goal, progress: 0 }
+    });
+    return addCountRoutineInstance;
+  }
+
+  async addBoolRoutineInstance(
+    routine_instance_id: string,
+    goal: boolean
+  ): Promise<RoutineInstanceWithGoal> {
+    const addBoolRoutineInstance = this.prisma.bool_routine_instance.create({
+      data: { routine_instance_id, goal, progress: false }
+    });
+    return addBoolRoutineInstance;
   }
 }

--- a/src/backend/repositories/PrismaRoutineInstanceRepository.ts
+++ b/src/backend/repositories/PrismaRoutineInstanceRepository.ts
@@ -47,7 +47,6 @@ export class PrismaRoutineInstanceRepository
     if (routineInstanceGoal) {
       return {
         routine_instance_id: routineInstance.routine_instance_id,
-        created_at: routineInstance.created_at,
         goal: routineInstanceGoal.goal,
         progress: routineInstanceGoal.progress
       };

--- a/src/backend/repositories/PrismaRoutineInstanceRepository.ts
+++ b/src/backend/repositories/PrismaRoutineInstanceRepository.ts
@@ -4,8 +4,11 @@ import {
   count_routine_instance,
   time_routine_instance
 } from '@prisma/client';
-import { Routine, RoutineInstance } from 'models/Routine';
-import { RoutineInstanceWithGoal } from 'models/Routine';
+import {
+  Routine,
+  RoutineInstance,
+  RoutineInstanceWithGoal
+} from 'models/Routine';
 import { RoutineInstanceRepository } from 'repositories/RoutineInstanceRepository';
 
 export class PrismaRoutineInstanceRepository

--- a/src/backend/repositories/PrismaRoutineRepository.ts
+++ b/src/backend/repositories/PrismaRoutineRepository.ts
@@ -1,7 +1,6 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, RoutineType as PrismaRoutineType } from '@prisma/client';
 import { Routine } from 'models/Routine';
 import { RoutineRepository } from 'repositories/RoutineRepository';
-import { RoutineType as PrismaRoutineType } from '@prisma/client';
 
 export class PrismaRoutineRepository implements RoutineRepository {
   constructor(private prisma: PrismaClient) {}

--- a/src/backend/repositories/PrismaRoutineRepository.ts
+++ b/src/backend/repositories/PrismaRoutineRepository.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { Routine } from 'models/Routine';
 import { RoutineRepository } from 'repositories/RoutineRepository';
+import { RoutineType as PrismaRoutineType } from '@prisma/client';
 
 export class PrismaRoutineRepository implements RoutineRepository {
   constructor(private prisma: PrismaClient) {}
@@ -11,5 +12,24 @@ export class PrismaRoutineRepository implements RoutineRepository {
     });
 
     return routine;
+  }
+
+  async addRoutine(
+    user_id: string,
+    title: string,
+    type: PrismaRoutineType,
+    daysOfWeek: string
+  ): Promise<Routine> {
+    const addedRoutine = await this.prisma.routine.create({
+      data: {
+        user_id,
+        title,
+        type,
+        is_repeat: true,
+        days_of_week_binary: daysOfWeek
+      }
+    });
+
+    return addedRoutine;
   }
 }

--- a/src/backend/repositories/RoutineInstanceRepository.ts
+++ b/src/backend/repositories/RoutineInstanceRepository.ts
@@ -1,5 +1,22 @@
-import { Routine, RoutineInstanceWithGoal } from 'models/Routine';
+import {
+  Routine,
+  RoutineInstance,
+  RoutineInstanceWithGoal
+} from 'models/Routine';
 
 export interface RoutineInstanceRepository {
   getRoutineInstance(routine: Routine): Promise<RoutineInstanceWithGoal | null>;
+  addRoutineInstance(routine_id: string): Promise<RoutineInstance>;
+  addTimeRoutineInstance(
+    routine_instance_id: string,
+    goal: number
+  ): Promise<RoutineInstanceWithGoal>;
+  addCountRoutineInstance(
+    routine_instance_id: string,
+    goal: number
+  ): Promise<RoutineInstanceWithGoal>;
+  addBoolRoutineInstance(
+    routine_instance_id: string,
+    goal: boolean
+  ): Promise<RoutineInstanceWithGoal>;
 }

--- a/src/backend/repositories/RoutineRepository.ts
+++ b/src/backend/repositories/RoutineRepository.ts
@@ -1,5 +1,12 @@
 import { Routine } from 'models/Routine';
+import { RoutineType as PrismaRoutineType } from '@prisma/client';
 
 export interface RoutineRepository {
   getRoutinesByUserId(user_id: string): Promise<Routine[]>;
+  addRoutine(
+    user_id: string,
+    title: string,
+    type: PrismaRoutineType,
+    daysOfWeek: string
+  ): Promise<Routine>;
 }

--- a/src/backend/services/RoutineService.ts
+++ b/src/backend/services/RoutineService.ts
@@ -1,14 +1,86 @@
-import { Routine } from 'models/Routine';
+import { Routine, RoutineInstanceWithGoal } from 'models/Routine';
 import { RoutineRepository } from 'repositories/RoutineRepository';
 import { RoutineInstanceRepository } from 'repositories/RoutineInstanceRepository';
 import { utcToZonedTime } from 'date-fns-tz';
 import { getDay } from 'date-fns';
+import { RoutineType as PrismaRoutineType } from '@prisma/client';
 
 export class RoutineUseCase {
   constructor(
     private routineRepository: RoutineRepository,
     private routineInstanceRepository: RoutineInstanceRepository
   ) {}
+
+  async addRoutine(
+    userId: string,
+    title: string,
+    type: PrismaRoutineType,
+    daysOfWeek: string[],
+    goal: string
+  ) {
+    // 1. create routine
+    const days = ['일', '월', '화', '수', '목', '금', '토'];
+    const daysOfWeekBinary = days
+      .map((day) =>
+        daysOfWeek.find((inputDay) => inputDay === day) ? '1' : '0'
+      )
+      .join('');
+
+    const routine = await this.routineRepository.addRoutine(
+      userId,
+      title,
+      type,
+      daysOfWeekBinary
+    );
+
+    // 2. create routine_instance
+    const routineInstance =
+      await this.routineInstanceRepository.addRoutineInstance(
+        routine.routine_id
+      );
+
+    let routineTypeInstance: RoutineInstanceWithGoal;
+    // 3. create type_routine_instance
+    switch (routine.type) {
+      case 'time':
+        routineTypeInstance =
+          await this.routineInstanceRepository.addTimeRoutineInstance(
+            routineInstance.routine_instance_id,
+            Number(goal)
+          );
+        break;
+
+      case 'count':
+        routineTypeInstance =
+          await this.routineInstanceRepository.addCountRoutineInstance(
+            routineInstance.routine_instance_id,
+            Number(goal)
+          );
+        break;
+
+      case 'bool':
+        routineTypeInstance =
+          await this.routineInstanceRepository.addBoolRoutineInstance(
+            routineInstance.routine_instance_id,
+            goal === 'true'
+          );
+        break;
+      default:
+        throw new Error('routine의 타입이 정확하지 않습니다.');
+    }
+
+    const res = {
+      routine_instance_id: routineInstance.routine_instance_id,
+      created_at: routineInstance.created_at,
+      title: routine.title,
+      type: routine.type,
+      days_of_week: daysOfWeek,
+      goal: routineTypeInstance.goal,
+      progress: routineTypeInstance.progress
+    };
+
+    return res;
+  }
 
   async getTodayRoutine(userId: string) {
     const day = ['일', '월', '화', '수', '목', '금', '토'];

--- a/src/backend/services/RoutineService.ts
+++ b/src/backend/services/RoutineService.ts
@@ -86,7 +86,7 @@ export class RoutineUseCase {
     const day = ['일', '월', '화', '수', '목', '금', '토'];
     const routines = await this.routineRepository.getRoutinesByUserId(userId);
     const filteredTodayRoutines = this.filterTodayRoutines(routines);
-    return filteredTodayRoutines.map(async (routine) => {
+    const routinesPromises = filteredTodayRoutines.map(async (routine) => {
       const daysOfWeek = routine.days_of_week_binary
         .split('')
         .map((binaryDay, idx) => {
@@ -102,9 +102,11 @@ export class RoutineUseCase {
         ...routineInstance,
         title: routine.title,
         type: routine.type,
-        days_of_week: daysOfWeek
+        days_of_week: daysOfWeek,
+        created_at: routine.created_at
       };
     });
+    return Promise.all(routinesPromises);
   }
 
   filterTodayRoutines(routines: Routine[]) {

--- a/src/pages/api/user/[userId]/routines.ts
+++ b/src/pages/api/user/[userId]/routines.ts
@@ -6,6 +6,7 @@ import { PrismaUserRepository } from 'repositories/PrismaUserRepository';
 import { PrismaRoutineRepository } from 'repositories/PrismaRoutineRepository';
 import { PrismaRoutineInstanceRepository } from 'repositories/PrismaRoutineInstanceRepository';
 import { isValidDate } from '@/backend/utils/dateUtil';
+import { RoutineType as PrismaRoutineType } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -41,7 +42,76 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       }
 
       const routines = await routineService.getTodayRoutine(userId as string);
-      res.status(200).json(routines);
+      return res.status(200).json(routines);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ error: 'Unexpected error occurred' });
+    }
+  } else if (req.method === 'POST') {
+    const { userId } = req.query;
+    const { title, type, daysOfWeek, goal } = req.body;
+
+    const errors = [];
+
+    if (!title || typeof title !== 'string') {
+      errors.push({
+        field: 'title',
+        message: 'Title is required and should be a string'
+      });
+    }
+    if (!type || !Object.values(PrismaRoutineType).includes(type)) {
+      errors.push({
+        field: 'type',
+        message: 'Type is required and Invalid type'
+      });
+    }
+    if (
+      !daysOfWeek ||
+      !Array.isArray(daysOfWeek) ||
+      !daysOfWeek.every((item) => typeof item === 'string')
+    ) {
+      errors.push({
+        field: 'daysOfWeek',
+        message: 'DaysOfWeek is required and should be an array of strings'
+      });
+    }
+    if (!goal || typeof goal !== 'string') {
+      errors.push({
+        field: 'goal',
+        message: 'Goal is required and should be a string'
+      });
+    }
+    if (errors.length > 0) {
+      return res.status(400).json({ errors: errors });
+    }
+
+    const userRepository = new PrismaUserRepository(prisma);
+    const routineRepository = new PrismaRoutineRepository(prisma);
+    const routineInstanceRepository = new PrismaRoutineInstanceRepository(
+      prisma
+    );
+
+    const userService = new UserUseCase(userRepository);
+    const routineService = new RoutineUseCase(
+      routineRepository,
+      routineInstanceRepository
+    );
+
+    try {
+      const user = await userService.getUserById(userId as string);
+      if (!user) {
+        return res
+          .status(404)
+          .json({ error: 'User with provided ID not found.' });
+      }
+      const newRoutine = await routineService.addRoutine(
+        userId as string,
+        title,
+        type,
+        daysOfWeek,
+        goal
+      );
+      return res.status(201).json({ routine: newRoutine });
     } catch (error) {
       console.error(error);
       res.status(500).json({ error: 'Unexpected error occurred' });


### PR DESCRIPTION
## 🍀 개요

routine 생성하는 api 추가
routine 가져오는 api 버그픽스
- promise 핸들링 오류 발견 후 고침

## ✏️ 작업 내용

- [x] 불필요한 필드 삭제 - 33dbf70a489b46d0fd5bd4a585a2ae7b70b25b06
- [x] 루틴 생성하는 api controller, service, repository - 1bde3a4bdcdaef7279c67bc7c6fbe204baa95b93, 0708134b17363e89f234447141fd47e8ca669854, c4cb41224863efcdebedfccfee0cd1e2acccc9e5, 5d9ce1d8cd46ca29c18843c90c7e3305ce305cdf
- [x] 루틴 가져오는 api 버그픽스 - 7ee1d9938f1ea0690bfa9600cbb8f6f986f3bf45


- 루틴 post 테스트
<img width="1076" alt="스크린샷 2023-06-15 오전 12 51 11" src="https://github.com/selfmenagement/front/assets/65802921/db8a9012-22d6-4a8b-8904-27c82736f25b">

- 루틴 get 테스트
<img width="1067" alt="스크린샷 2023-06-15 오전 12 51 41" src="https://github.com/selfmenagement/front/assets/65802921/035a6c5e-fdce-4199-87c5-9e9b8df58673">



## 🔎 추가 정보
close #46 
