### PR TITLE
[Feat] #49 add routine edit api

### DIFF
--- a/src/backend/repositories/PrismaRoutineInstanceRepository.ts
+++ b/src/backend/repositories/PrismaRoutineInstanceRepository.ts
@@ -96,4 +96,82 @@ export class PrismaRoutineInstanceRepository
     });
     return addBoolRoutineInstance;
   }
+
+  async getRoutineInstanceById(
+    routine_instance_id: string
+  ): Promise<RoutineInstance | null> {
+    const routineInstance = await this.prisma.routine_instance.findUnique({
+      where: { routine_instance_id }
+    });
+    return routineInstance;
+  }
+
+  async editTimeRoutineInstance(
+    routine_instance_id: string,
+    progress: number
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const timeRoutineInstance =
+      await this.prisma.time_routine_instance.findFirst({
+        where: { routine_instance_id }
+      });
+
+    const newTimeRoutineInstance =
+      await this.prisma.time_routine_instance.update({
+        where: {
+          time_routine_instance_id:
+            timeRoutineInstance?.time_routine_instance_id
+        },
+        data: {
+          progress
+        }
+      });
+
+    return newTimeRoutineInstance;
+  }
+
+  async editCountRoutineInstance(
+    routine_instance_id: string,
+    progress: number
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const countRoutineInstance =
+      await this.prisma.count_routine_instance.findFirst({
+        where: { routine_instance_id }
+      });
+
+    const newCountRoutineInstance =
+      await this.prisma.count_routine_instance.update({
+        where: {
+          count_routine_instance_id:
+            countRoutineInstance?.count_routine_instance_id
+        },
+        data: {
+          progress
+        }
+      });
+
+    return newCountRoutineInstance;
+  }
+
+  async editBoolRoutineInstance(
+    routine_instance_id: string,
+    progress: boolean
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const boolRoutineInstance =
+      await this.prisma.bool_routine_instance.findFirst({
+        where: { routine_instance_id }
+      });
+
+    const newBoolRoutineInstance =
+      await this.prisma.bool_routine_instance.update({
+        where: {
+          bool_routine_instance_id:
+            boolRoutineInstance?.bool_routine_instance_id
+        },
+        data: {
+          progress
+        }
+      });
+
+    return newBoolRoutineInstance;
+  }
 }

--- a/src/backend/repositories/RoutineInstanceRepository.ts
+++ b/src/backend/repositories/RoutineInstanceRepository.ts
@@ -19,4 +19,19 @@ export interface RoutineInstanceRepository {
     routine_instance_id: string,
     goal: boolean
   ): Promise<RoutineInstanceWithGoal>;
+  editTimeRoutineInstance(
+    routine_instance_id: string,
+    progress: number
+  ): Promise<RoutineInstanceWithGoal | null>;
+  editCountRoutineInstance(
+    routine_instance_id: string,
+    progress: number
+  ): Promise<RoutineInstanceWithGoal | null>;
+  editBoolRoutineInstance(
+    routine_instance_id: string,
+    progress: boolean
+  ): Promise<RoutineInstanceWithGoal | null>;
+  getRoutineInstanceById(
+    routine_instance_id: string
+  ): Promise<RoutineInstance | null>;
 }

--- a/src/backend/services/RoutineService.ts
+++ b/src/backend/services/RoutineService.ts
@@ -1,4 +1,8 @@
-import { Routine, RoutineInstanceWithGoal } from 'models/Routine';
+import {
+  Routine,
+  RoutineInstance,
+  RoutineInstanceWithGoal
+} from 'models/Routine';
 import { RoutineRepository } from 'repositories/RoutineRepository';
 import { RoutineInstanceRepository } from 'repositories/RoutineInstanceRepository';
 import { utcToZonedTime } from 'date-fns-tz';
@@ -115,5 +119,87 @@ export class RoutineUseCase {
     return routines.filter(
       (routine) => routine.days_of_week_binary.charAt(day) === '1'
     );
+  }
+
+  async getRoutineInstanceById(
+    routineInstanceId: string
+  ): Promise<RoutineInstance | null> {
+    const routineInstance =
+      this.routineInstanceRepository.getRoutineInstanceById(routineInstanceId);
+    return routineInstance;
+  }
+
+  async editRoutineInstanceProgress(
+    routineInstance: RoutineInstance,
+    type: PrismaRoutineType,
+    progress: number | boolean
+  ): Promise<RoutineInstanceWithGoal> {
+    let typeRoutineInstance: RoutineInstanceWithGoal | null;
+    switch (type) {
+      case 'time':
+        typeRoutineInstance = await this.editTimeRoutineInstance(
+          routineInstance.routine_instance_id,
+          progress as number
+        );
+        break;
+      case 'count':
+        typeRoutineInstance = await this.editCountRoutineInstance(
+          routineInstance.routine_instance_id,
+          progress as number
+        );
+        break;
+      case 'bool':
+        typeRoutineInstance = await this.editBoolRoutineInstance(
+          routineInstance.routine_instance_id,
+          progress as boolean
+        );
+        break;
+      default:
+        throw new Error('routine의 타입이 정확하지 않습니다.');
+    }
+
+    if (!typeRoutineInstance) {
+      throw new Error('routine instance 제대로 저장되지 않았습니다.');
+    }
+    return typeRoutineInstance;
+  }
+
+  private async editTimeRoutineInstance(
+    routineInstanceId: string,
+    progress: number
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const timeRoutineInstance =
+      await this.routineInstanceRepository.editTimeRoutineInstance(
+        routineInstanceId,
+        progress
+      );
+
+    return timeRoutineInstance;
+  }
+
+  private async editCountRoutineInstance(
+    routineInstanceId: string,
+    progress: number
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const countRoutineInstance =
+      await this.routineInstanceRepository.editCountRoutineInstance(
+        routineInstanceId,
+        progress
+      );
+
+    return countRoutineInstance;
+  }
+
+  private async editBoolRoutineInstance(
+    routineInstanceId: string,
+    progress: boolean
+  ): Promise<RoutineInstanceWithGoal | null> {
+    const boolRoutineInstance =
+      await this.routineInstanceRepository.editBoolRoutineInstance(
+        routineInstanceId,
+        progress
+      );
+
+    return boolRoutineInstance;
   }
 }

--- a/src/pages/api/user/[userId]/routine-instance/[routineInstanceId].ts
+++ b/src/pages/api/user/[userId]/routine-instance/[routineInstanceId].ts
@@ -1,8 +1,8 @@
-import { PrismaRoutineInstanceRepository } from '@/backend/repositories/PrismaRoutineInstanceRepository';
-import { PrismaRoutineRepository } from '@/backend/repositories/PrismaRoutineRepository';
-import { PrismaUserRepository } from '@/backend/repositories/PrismaUserRepository';
-import { RoutineUseCase } from '@/backend/services/RoutineService';
-import { UserUseCase } from '@/backend/services/UserService';
+import { PrismaRoutineInstanceRepository } from 'repositories/PrismaRoutineInstanceRepository';
+import { PrismaRoutineRepository } from 'repositories/PrismaRoutineRepository';
+import { PrismaUserRepository } from 'repositories/PrismaUserRepository';
+import { RoutineUseCase } from 'services/RoutineService';
+import { UserUseCase } from 'services/UserService';
 import { PrismaClient, RoutineType as PrismaRoutineType } from '@prisma/client';
 import { NextApiRequest, NextApiResponse } from 'next';
 

--- a/src/pages/api/user/[userId]/routine-instance/[routineInstanceId].ts
+++ b/src/pages/api/user/[userId]/routine-instance/[routineInstanceId].ts
@@ -1,0 +1,109 @@
+import { PrismaRoutineInstanceRepository } from '@/backend/repositories/PrismaRoutineInstanceRepository';
+import { PrismaRoutineRepository } from '@/backend/repositories/PrismaRoutineRepository';
+import { PrismaUserRepository } from '@/backend/repositories/PrismaUserRepository';
+import { RoutineUseCase } from '@/backend/services/RoutineService';
+import { UserUseCase } from '@/backend/services/UserService';
+import { PrismaClient, RoutineType as PrismaRoutineType } from '@prisma/client';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const prisma = new PrismaClient();
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'PUT') {
+    const { userId, routineInstanceId } = req.query;
+    const { type, progress } = req.body;
+
+    const errors = [];
+
+    if (!routineInstanceId || typeof routineInstanceId !== 'string') {
+      errors.push({
+        field: 'routineInstanceId',
+        message: 'RoutineInstanceId is required and should be a string'
+      });
+    }
+    if (!userId || typeof userId !== 'string') {
+      errors.push({
+        field: 'userId',
+        message: 'UserId is required and should be a string'
+      });
+    }
+    if (!type || !Object.values(PrismaRoutineType).includes(type)) {
+      errors.push({
+        field: 'type',
+        message: 'Type is required and Invalid type'
+      });
+    }
+    if (typeof progress !== 'number' && typeof progress !== 'boolean') {
+      errors.push({
+        field: 'progress',
+        message: 'progress is required and should be a number or boolean'
+      });
+    }
+    if (typeof progress === 'number' && type === 'bool') {
+      errors.push({
+        field: 'progress, type',
+        message: 'progress and type shoud be match'
+      });
+    }
+    if (
+      typeof progress === 'boolean' &&
+      (type === 'time' || type === 'count')
+    ) {
+      errors.push({
+        field: 'progress, type',
+        message: 'progress and type shoud be match'
+      });
+    }
+    if (errors.length > 0) {
+      return res.status(400).json({ errors: errors });
+    }
+
+    const userRepository = new PrismaUserRepository(prisma);
+    const userService = new UserUseCase(userRepository);
+
+    const routineRepository = new PrismaRoutineRepository(prisma);
+    const routineInstanceRepository = new PrismaRoutineInstanceRepository(
+      prisma
+    );
+
+    const routineService = new RoutineUseCase(
+      routineRepository,
+      routineInstanceRepository
+    );
+
+    try {
+      const user = await userService.getUserById(userId as string);
+      if (!user) {
+        return res
+          .status(404)
+          .json({ error: 'User with provided ID not found.' });
+      }
+
+      const routineInstance = await routineService.getRoutineInstanceById(
+        routineInstanceId as string
+      );
+      if (!routineInstance) {
+        return res
+          .status(404)
+          .json({ error: 'Routine with provided instance ID not found' });
+      }
+
+      const typeRoutineInstance =
+        await routineService.editRoutineInstanceProgress(
+          routineInstance,
+          type,
+          progress
+        );
+
+      const result = {
+        routine_instance_id: routineInstance.routine_instance_id,
+        type: type,
+        progress: typeRoutineInstance.progress
+      };
+
+      return res.status(200).json(result);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+};


### PR DESCRIPTION
## 🍀 개요

routine-instance를 수정하는 api추가

## ✏️ 작업 내용

- [x] routine-instance edit 컨트롤러 - 196d60630b48c9c72aafffdfbba735b43367f495
- [x] routine-instance edit 서비스 - babb60e4c3148b7d0bf5cf55753fe5719f7f0858
- [x] routine-instance edit 레포지토리 - fa5282a061f1f89599cd7c3a515336819f1e4dba


<img width="1089" alt="스크린샷 2023-06-15 오후 5 01 46" src="https://github.com/selfmenagement/front/assets/65802921/1ad76956-4e10-4fb9-8c30-5b43e00e1e9c">

## 🔎 추가 정보
api에 대한 자세한 내용은 notion 문서를 참고해주세요
- close #49 